### PR TITLE
Refactor Sidebar and Debug Frames into Helper Classes

### DIFF
--- a/src/view/helperclasses/DebugFrame.py
+++ b/src/view/helperclasses/DebugFrame.py
@@ -1,0 +1,50 @@
+import tkinter as tk
+import customtkinter as ctk
+
+from view.customframes.CheckboxFrame import CheckboxFrame
+
+class DebugFrame(ctk.CTkFrame):
+
+    def __init__(self, parent):
+        
+        super().__init__(parent)
+        
+        self.parent = parent
+
+        # Grid Configuration
+        self.grid_columnconfigure(0, weight=1)
+        self.grid_rowconfigure((0,1,2), weight=1)
+
+        # Frame Title
+        self.debug_frame_title = ctk.CTkLabel(self, text="Debugging Tools", font=("Arial", 16), justify="center")
+        
+        self.checkbox_frame = self.init_debug_checkbox_frame()
+    
+        self.debug_context_frame = self.init_debug_context_frame()
+        
+        # Debug Frame Gridding
+        self.debug_frame_title.grid(row=0, column=0, padx=10, pady=10, sticky="ew")
+        self.checkbox_frame.grid(row=1, column=0, padx=10, pady=10, sticky="ew")
+
+
+        # Grid weight configuration
+
+    def init_debug_checkbox_frame(self):
+        
+        checkbox_frame = CheckboxFrame(self, 2, 1)
+        checkbox_frame.checkboxes[0].configure(text="Save Locally", command = lambda *args, widget = checkbox_frame.checkboxes[0]: self.parent.localsave_callback(widget))
+        checkbox_frame.checkboxes[0].select()   
+        checkbox_frame.checkboxes[1].configure(text="Edit Mode", command =  self.parent.set_edit_mode)
+        
+        return checkbox_frame
+        
+    def init_debug_context_frame(self):
+        
+        # Debug Context Frame
+        debug_context_frame = ctk.CTkFrame(self)
+        debug_context_frame.grid_columnconfigure(0, weight=1)
+        
+        # Context Frame Edit Mode
+        self.debug_button = ctk.CTkButton(debug_context_frame, text="Toggle fields", command = self.parent.toggle_all_fields)
+        
+        return debug_context_frame

--- a/src/view/helperclasses/SidebarFrame.py
+++ b/src/view/helperclasses/SidebarFrame.py
@@ -1,0 +1,79 @@
+import tkinter as tk
+import customtkinter as ctk
+
+from view.customframes.ButtonFrame import ButtonFrame
+from view.customframes.CheckboxFrame import CheckboxFrame
+        
+class SidebarFrame(ctk.CTkFrame):
+    
+    def __init__(self, parent):
+                
+        # Sidebar Frame 1x5 Grid
+        super().__init__(parent)
+        
+        self.parent = parent
+          
+        self.grid_columnconfigure(0, weight=1)
+        
+        self.file_frame = self.init_file_frame()
+        self.file_frame.grid(row=1, column=0, padx=10, pady=10, sticky="ew")
+        
+        self.generate_frame = self.init_generate_frame()
+        self.generate_frame.grid(row=2, column=0, padx=10, pady=10, sticky="ew")
+        
+    
+    def init_file_frame(self):
+        
+         # File Load Frame Configuration
+        file_frame = ctk.CTkFrame(self)
+        
+        # File Button Frame
+        self.file_button_frame = ButtonFrame(file_frame, rows = 1, columns = 2, sticky="ew")   
+        self.file_button_frame.buttons[0].configure(text="Save", command = self.parent.savebutton_callback)
+        self.file_button_frame.buttons[1].configure(text="Load", command = self.parent.loadbutton_callback)
+           
+        # File Selection Dropdown and Label
+        self.load_label = ctk.CTkLabel(file_frame, text="Select File", font=("Arial", 16), justify="center")
+        self.load_dropdown = ctk.CTkComboBox(file_frame, font=("Arial", 16), dropdown_font=("Arial", 14), justify="center", values=[""], command=self.parent.dropdown_callback, state="readonly")
+        
+        # Gridding
+        self.load_label.grid(row=0, column=0, padx=25, pady=10, sticky="ew")
+        self.load_dropdown.grid(row=1, column=0, padx=25, pady=25, sticky="ew")
+        self.file_button_frame.grid(row=2, column=0, padx=25, pady=10, sticky="nsew")
+        
+        # Grid weight configuration
+        file_frame.grid_columnconfigure(0, weight=1)
+        
+        return file_frame
+    
+    def init_generate_frame(self):
+        
+        # Sudoku Generation Frame
+        generate_frame = ctk.CTkFrame(self)
+        
+        # Generate Title
+        generate_frame_title = ctk.CTkLabel(generate_frame, text="Sudoku Generation", font=("Arial", 16), justify="center")
+        
+        # Generate Button Frame
+        self.generate_button_frame = ButtonFrame(generate_frame, rows = 1, columns = 2, sticky="ew")
+        self.generate_button_frame.buttons[0].configure(text="Generate", command = self.parent.generatebutton_callback)
+        self.generate_button_frame.buttons[1].configure(text="Clear", command = self.parent.clearbutton_callback)
+        
+        # Generate Slider
+        self.generate_slider_frame = ctk.CTkFrame(generate_frame)
+        self.generate_slider_label = ctk.CTkLabel(self.generate_slider_frame, text="Difficulty = Medium", font=("Arial", 16), justify="center")
+        self.generate_slider = ctk.CTkSlider(self.generate_slider_frame, from_=0.3, to=0.7, orientation="horizontal", number_of_steps=8, command=self.parent.generateslider_callback)  
+        self.generate_slider_label.grid(row=0, column=0, padx=10, pady=10, sticky="ew")
+        self.generate_slider.grid(row=1, column=0, padx=10, pady=10, sticky="ew")
+        self.generate_slider_frame.grid_columnconfigure(0, weight=1)
+        
+        
+        # Gridding
+        generate_frame_title.grid(row=0, column=0, padx=10, pady=10, sticky="ew")
+        self.generate_button_frame.grid(row=1, column=0, padx=25, pady=10, sticky="nsew")
+        self.generate_slider_frame.grid(row=2, column=0, padx=25, pady=10, sticky="nsew")
+
+        # Grid weight configuration
+        generate_frame.grid_columnconfigure(0, weight=1)
+        
+        return generate_frame

--- a/src/view/helperclasses/SidebarFrame.py
+++ b/src/view/helperclasses/SidebarFrame.py
@@ -2,13 +2,11 @@ import tkinter as tk
 import customtkinter as ctk
 
 from view.customframes.ButtonFrame import ButtonFrame
-from view.customframes.CheckboxFrame import CheckboxFrame
         
 class SidebarFrame(ctk.CTkFrame):
     
     def __init__(self, parent):
                 
-        # Sidebar Frame 1x5 Grid
         super().__init__(parent)
         
         self.parent = parent
@@ -24,7 +22,7 @@ class SidebarFrame(ctk.CTkFrame):
     
     def init_file_frame(self):
         
-         # File Load Frame Configuration
+         # File Load Frame
         file_frame = ctk.CTkFrame(self)
         
         # File Button Frame

--- a/src/view/view.py
+++ b/src/view/view.py
@@ -6,6 +6,7 @@ from view.customframes.ButtonFrame import ButtonFrame
 from view.customframes.CheckboxFrame import CheckboxFrame
 
 from view.helperclasses.SidebarFrame import SidebarFrame
+from view.helperclasses.DebugFrame import DebugFrame
 
 
 class View(ctk.CTkFrame):
@@ -56,35 +57,10 @@ class View(ctk.CTkFrame):
         # Sidebar Frame
         self.sidebar_frame = SidebarFrame(self)
         self.sidebar_frame.grid(row=1, column=2, padx=10, pady=10, sticky="ew")
-        
            
-        # Debug Frame Configuration
-        self.debug_frame = ctk.CTkFrame(self)
+        # Debug Frame 
+        self.debug_frame = DebugFrame(self)
         self.debug_frame.grid(row=1, column=0, padx=10, pady=10, sticky="ew")
-        
-        # Frame Title
-        self.debug_frame_title = ctk.CTkLabel(self.debug_frame, text="Debugging Tools", font=("Arial", 16), justify="center")
-        
-    	# Debug Checkbox Frame
-        self.sudoku_checkbox_frame = CheckboxFrame(self.debug_frame, 2, 1)
-        self.sudoku_checkbox_frame.checkboxes[0].configure(text="Save Locally", command = lambda *args, widget = self.sudoku_checkbox_frame.checkboxes[0]: self.localsave_callback(widget))
-        self.sudoku_checkbox_frame.checkboxes[0].select()   
-        self.sudoku_checkbox_frame.checkboxes[1].configure(text="Edit Mode", command =  self.set_edit_mode)
-    
-        # Debug Context Frame
-        self.debug_context_frame = ctk.CTkFrame(self.debug_frame)
-        self.debug_context_frame.grid_columnconfigure(0, weight=1)
-        # Context Frame Edit Mode
-        self.debug_button = ctk.CTkButton(self.debug_context_frame, text="Toggle fields", command = self.toggle_all_fields)
-        
-        # Debug Frame Gridding
-        self.debug_frame_title.grid(row=0, column=0, padx=10, pady=10, sticky="ew")
-        self.sudoku_checkbox_frame.grid(row=1, column=0, padx=10, pady=10, sticky="ew")
-
-
-        # Grid weight configuration
-        self.debug_frame.grid_columnconfigure(0, weight=1)
-        self.debug_frame.grid_rowconfigure((0,1,2), weight=1)
         
 
 
@@ -99,13 +75,13 @@ class View(ctk.CTkFrame):
         self.widget_at_mouse = widget
 
     def set_edit_mode(self):
-        self.edit_mode = self.sudoku_checkbox_frame.checkboxes[1].get()
+        self.edit_mode = self.debug_frame.checkbox_frame.checkboxes[1].get()
         if self.edit_mode == 1:
-            self.debug_button.grid(row=0, column=0, padx=10, pady=10, sticky="ew")
-            self.debug_context_frame.grid(row=2, column=0, padx=10, pady=10, sticky="ew")
+            self.debug_frame.debug_button.grid(row=0, column=0, padx=10, pady=10, sticky="ew")
+            self.debug_frame.debug_context_frame.grid(row=2, column=0, padx=10, pady=10, sticky="ew")
         else:
-            self.debug_button.grid_forget()
-            self.debug_context_frame.grid_forget()
+            self.debug_frame.debug_button.grid_forget()
+            self.debug_frame.debug_context_frame.grid_forget()
         
 
     def mousebutton_callback(self):
@@ -409,7 +385,7 @@ class View(ctk.CTkFrame):
         return self.sudoku_frame.get_field(row, column).get_state()
 
     def set_mode(self, mode='normal'):
-        for checkbox in self.sudoku_checkbox_frame.checkboxes:
+        for checkbox in self.debug_frame.checkbox_frame.checkboxes:
             if mode == 'debug':
                 checkbox.select()
                 self.localsave_callback(checkbox)

--- a/src/view/view.py
+++ b/src/view/view.py
@@ -5,6 +5,8 @@ from view.customframes.SudokugridFrame import SudokuFrame
 from view.customframes.ButtonFrame import ButtonFrame
 from view.customframes.CheckboxFrame import CheckboxFrame
 
+from view.helperclasses.SidebarFrame import SidebarFrame
+
 
 class View(ctk.CTkFrame):
 
@@ -51,60 +53,10 @@ class View(ctk.CTkFrame):
                 self.sudoku_frame.get_field(row, column).entry_variable.trace_add("write", lambda *args, widget = self.sudoku_frame.get_field(row, column): self.entry_callback(widget))
 
 
-        # Sidebar Frame 1x5 Grid
-        self.sidebar_frame = ctk.CTkFrame(self)
-        self.sidebar_frame.grid(row=1, column=2, padx=10, pady=10, sticky="ew")   
-        self.sidebar_frame.grid_columnconfigure(0, weight=1)
+        # Sidebar Frame
+        self.sidebar_frame = SidebarFrame(self)
+        self.sidebar_frame.grid(row=1, column=2, padx=10, pady=10, sticky="ew")
         
-        # File Load Frame Configuration
-        self.file_frame = ctk.CTkFrame(self.sidebar_frame)
-        self.file_frame.grid(row=1, column=0, padx=10, pady=10, sticky="ew")
-        
-        # File Button Frame
-        self.file_button_frame = ButtonFrame(self.file_frame, rows = 1, columns = 2, sticky="ew")   
-        self.file_button_frame.buttons[0].configure(text="Save", command = self.savebutton_callback)
-        self.file_button_frame.buttons[1].configure(text="Load", command = self.loadbutton_callback)
-           
-        # File Selection Dropdown and Label
-        self.load_label = ctk.CTkLabel(self.file_frame, text="Select File", font=("Arial", 16), justify="center")
-        self.load_dropdown = ctk.CTkComboBox(self.file_frame, font=("Arial", 16), dropdown_font=("Arial", 14), justify="center", values=[""], command=self.dropdown_callback, state="readonly")
-        
-        # Gridding
-        self.load_label.grid(row=0, column=0, padx=25, pady=10, sticky="ew")
-        self.load_dropdown.grid(row=1, column=0, padx=25, pady=25, sticky="ew")
-        self.file_button_frame.grid(row=2, column=0, padx=25, pady=10, sticky="nsew")
-        
-        # Grid weight configuration
-        self.file_frame.grid_columnconfigure(0, weight=1)
-        
-        # Sudoku Generation Frame
-        self.generate_frame = ctk.CTkFrame(self.sidebar_frame)
-        self.generate_frame.grid(row=2, column=0, padx=10, pady=10, sticky="ew")
-        
-        # Generate Title
-        self.generate_frame_title = ctk.CTkLabel(self.generate_frame, text="Sudoku Generation", font=("Arial", 16), justify="center")
-        
-        # Generate Button Frame
-        self.generate_button_frame = ButtonFrame(self.generate_frame, rows = 1, columns = 2, sticky="ew")
-        self.generate_button_frame.buttons[0].configure(text="Generate", command = self.generatebutton_callback)
-        self.generate_button_frame.buttons[1].configure(text="Clear", command = self.clearbutton_callback)
-        
-        # Generate Slider
-        self.generate_slider_frame = ctk.CTkFrame(self.generate_frame)
-        self.generate_slider_label = ctk.CTkLabel(self.generate_slider_frame, text="Difficulty = Medium", font=("Arial", 16), justify="center")
-        self.generate_slider = ctk.CTkSlider(self.generate_slider_frame, from_=0.3, to=0.7, orientation="horizontal", number_of_steps=8, command=self.generateslider_callback)  
-        self.generate_slider_label.grid(row=0, column=0, padx=10, pady=10, sticky="ew")
-        self.generate_slider.grid(row=1, column=0, padx=10, pady=10, sticky="ew")
-        self.generate_slider_frame.grid_columnconfigure(0, weight=1)
-        
-        
-        # Gridding
-        self.generate_frame_title.grid(row=0, column=0, padx=10, pady=10, sticky="ew")
-        self.generate_button_frame.grid(row=1, column=0, padx=25, pady=10, sticky="nsew")
-        self.generate_slider_frame.grid(row=2, column=0, padx=25, pady=10, sticky="nsew")
-
-        # Grid weight configuration
-        self.generate_frame.grid_columnconfigure(0, weight=1)
            
         # Debug Frame Configuration
         self.debug_frame = ctk.CTkFrame(self)
@@ -142,8 +94,6 @@ class View(ctk.CTkFrame):
         
         self.dropdown_callback()
         
-        
-    
 
     def set_mouse_position(self, widget):
         self.widget_at_mouse = widget
@@ -184,19 +134,19 @@ class View(ctk.CTkFrame):
     def dropdown_callback(self, *args):
             files = self.controller.get_files()
             files.append("[ new file ]")
-            self.load_dropdown.configure(values=files)
-            if self.load_dropdown.get() == "[ new file ]":
-                self.file_button_frame.buttons[0].configure(state="normal")
-                self.load_dropdown.set("")
-                self.load_dropdown.configure(state="normal", text_color="#999999", dropdown_text_color="#999999")
-                self.load_dropdown.focus()
+            self.sidebar_frame.load_dropdown.configure(values=files)
+            if self.sidebar_frame.load_dropdown.get() == "[ new file ]":
+                self.sidebar_frame.file_button_frame.buttons[0].configure(state="normal")
+                self.sidebar_frame.load_dropdown.set("")
+                self.sidebar_frame.load_dropdown.configure(state="normal", text_color="#999999", dropdown_text_color="#999999")
+                self.sidebar_frame.load_dropdown.focus()
             else:
-                self.load_dropdown.configure(state="readonly", text_color="#99FF99", dropdown_text_color="#99FF99")
+                self.sidebar_frame.load_dropdown.configure(state="readonly", text_color="#99FF99", dropdown_text_color="#99FF99")
             
-            if not self.controller.is_file_writeable(self.load_dropdown.get()):
-                self.file_button_frame.buttons[0].configure(state="disabled")
+            if not self.controller.is_file_writeable(self.sidebar_frame.load_dropdown.get()):
+                self.sidebar_frame.file_button_frame.buttons[0].configure(state="disabled")
             else:
-                self.file_button_frame.buttons[0].configure(state="normal")
+                self.sidebar_frame.file_button_frame.buttons[0].configure(state="normal")
 
 
     def fetchbutton_callback(self):
@@ -225,7 +175,7 @@ class View(ctk.CTkFrame):
 
     def savebutton_callback(self):
         if self.controller: 
-            file_name = self.load_dropdown.get()
+            file_name = self.sidebar_frame.load_dropdown.get()
             
             
             if file_name != "":
@@ -237,7 +187,7 @@ class View(ctk.CTkFrame):
         
     def loadbutton_callback(self):
         if self.controller:
-            file_name = self.load_dropdown.get()
+            file_name = self.sidebar_frame.load_dropdown.get()
             self.reset_highlighted_fields()
             if file_name != "":
                 self.controller.load(file_name)


### PR DESCRIPTION
Move the Sidebar and Debug frames into separate helper classes to simplify the main view and improve code organization. Clean up comments and imports for better readability.